### PR TITLE
Bug Fixes: RadioGroup inline & readonly for textfield

### DIFF
--- a/src/AddButton.js
+++ b/src/AddButton.js
@@ -1,5 +1,6 @@
 import React from "react";
-import { Button, Icon } from "@material-ui/core";
+import Button from "@material-ui/core/Button";
+import Icon from "@material-ui/core/Icon";
 
 function _AddButton(props) {
   const { icon, className, ...otherProps } = props;

--- a/src/ArrayFieldTemplate.js
+++ b/src/ArrayFieldTemplate.js
@@ -5,7 +5,8 @@ import {
 } from "react-jsonschema-form/lib/utils";
 import IconButton from "./IconButton";
 import AddButton from "./AddButton";
-import { Paper, Grid } from "@material-ui/core";
+import Paper from "@material-ui/core/Paper";
+import Grid from "@material-ui/core/Grid";
 
 export default function ArrayFieldTemplate(props) {
   const { schema, registry = getDefaultRegistry() } = props;

--- a/src/ErrorList.js
+++ b/src/ErrorList.js
@@ -1,13 +1,11 @@
 import React from "react";
-import {
-  Typography,
-  List,
-  ListItem,
-  ListItemIcon,
-  Icon,
-  ListItemText,
-  Paper,
-} from "@material-ui/core";
+import Typography from "@material-ui/core/Typography";
+import List from "@material-ui/core/List";
+import ListItem from "@material-ui/core/ListItem";
+import ListItemIcon from "@material-ui/core/ListItemIcon";
+import Icon from "@material-ui/core/Icon";
+import ListItemText from "@material-ui/core/ListItemText";
+import Paper from "@material-ui/core/Paper";
 
 export default function ErrorList(props) {
   const { errors } = props;

--- a/src/FieldTemplate.js
+++ b/src/FieldTemplate.js
@@ -1,6 +1,8 @@
 import { ADDITIONAL_PROPERTY_FLAG } from "react-jsonschema-form/lib/utils";
 import React from "react";
-import { TextField, FormLabel, Typography } from "@material-ui/core";
+import TextField from "@material-ui/core/TextField";
+import FormLabel from "@material-ui/core/FormLabel";
+import Typography from "@material-ui/core/Typography";
 
 export default function DefaultTemplate(props) {
   const {

--- a/src/IconButton.js
+++ b/src/IconButton.js
@@ -1,5 +1,6 @@
 import React from "react";
-import { Button, Icon } from "@material-ui/core";
+import Button from "@material-ui/core/Button";
+import Icon from "@material-ui/core/Icon";
 
 let mappings = {
   remove: "delete",

--- a/src/ObjectFieldTemplate.js
+++ b/src/ObjectFieldTemplate.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Paper } from "@material-ui/core";
+import Paper from "@material-ui/core/Paper";
 import AddButton from "./AddButton";
 import { getUiOptions } from "react-jsonschema-form/lib/utils";
 

--- a/src/fields/DescriptionField.js
+++ b/src/fields/DescriptionField.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { Typography } from "@material-ui/core";
+import Typography from "@material-ui/core/Typography";
 
 function DescriptionField(props) {
   const { id, description } = props;

--- a/src/fields/TitleField.js
+++ b/src/fields/TitleField.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { Typography } from "@material-ui/core";
+import Typography from "@material-ui/core/Typography";
 
 const REQUIRED_FIELD_SYMBOL = "*";
 

--- a/src/widgets/AltDateWidget.js
+++ b/src/widgets/AltDateWidget.js
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import { Grid, Button } from "@material-ui/core";
+import Grid from "@material-ui/core/Grid";
+import Button from "@material-ui/core/Button";
 
 import {
   shouldRender,

--- a/src/widgets/BaseInput.js
+++ b/src/widgets/BaseInput.js
@@ -11,7 +11,6 @@ function BaseInput(props) {
   }
   const {
     value,
-    readonly,
     disabled,
     autofocus,
     onBlur,
@@ -32,13 +31,13 @@ function BaseInput(props) {
   const _onChange = ({ target: { value } }) => {
     return props.onChange(value === "" ? options.emptyValue : value);
   };
-
+  const readonly = schema ? schema.readOnly : false;
   return (
     <TextField
       className={classes.textField}
       margin="dense"
       readOnly={readonly}
-      disabled={disabled}
+      disabled={disabled || readonly}
       autoFocus={autofocus}
       fullWidth={true}
       error={rawErrors && rawErrors.length > 0}

--- a/src/widgets/CheckboxWidget.js
+++ b/src/widgets/CheckboxWidget.js
@@ -1,12 +1,10 @@
 import React from "react";
 import PropTypes from "prop-types";
 import DescriptionField from "../fields/DescriptionField.js";
-import {
-  FormControl,
-  FormControlLabel,
-  FormHelperText,
-  Checkbox,
-} from "@material-ui/core";
+import Checkbox from "@material-ui/core/Checkbox";
+import FormControl from "@material-ui/core/FormControl";
+import FormHelperText from "@material-ui/core/FormHelperText";
+import FormControlLabel from "@material-ui/core/FormControlLabel";
 
 function CheckboxWidget(props) {
   const {

--- a/src/widgets/CheckboxesWidget.js
+++ b/src/widgets/CheckboxesWidget.js
@@ -1,13 +1,11 @@
 import React from "react";
 import PropTypes from "prop-types";
-import {
-  FormControl,
-  FormLabel,
-  FormGroup,
-  FormHelperText,
-  FormControlLabel,
-  Checkbox,
-} from "@material-ui/core";
+import FormControl from "@material-ui/core/FormControl";
+import FormLabel from "@material-ui/core/FormLabel";
+import FormGroup from "@material-ui/core/FormGroup";
+import FormControlLabel from "@material-ui/core/FormControlLabel";
+import FormHelperText from "@material-ui/core/FormHelperText";
+import Checkbox from "@material-ui/core/Checkbox";
 
 function selectValue(value, selected, all) {
   const at = all.indexOf(value);

--- a/src/widgets/RadioWidget.js
+++ b/src/widgets/RadioWidget.js
@@ -1,13 +1,11 @@
 import React from "react";
 import PropTypes from "prop-types";
-import {
-  Radio,
-  RadioGroup,
-  FormControl,
-  FormControlLabel,
-  FormLabel,
-  FormHelperText,
-} from "@material-ui/core";
+import Radio from "@material-ui/core/Radio";
+import RadioGroup from "@material-ui/core/RadioGroup";
+import FormControl from "@material-ui/core/FormControl";
+import FormControlLabel from "@material-ui/core/FormControlLabel";
+import FormLabel from "@material-ui/core/FormLabel";
+import FormHelperText from "@material-ui/core/FormHelperText";
 
 function RadioWidget(props) {
   const {
@@ -31,6 +29,7 @@ function RadioWidget(props) {
     onChange(schema.type == "boolean" ? value !== "false" : value);
   // checked={checked} has been moved above name={name}, As mentioned in #349;
   // this is a temporary fix for radio button rendering bug in React, facebook/react#7630.
+  const row = options ? options.inline : false;
   return (
     <FormControl
       variant="outlined"
@@ -47,7 +46,8 @@ function RadioWidget(props) {
         className="field-radio-group"
         value={`${value}`}
         onChange={_onChange}
-        required={required}>
+        required={required}
+        row={row}>
         {enumOptions.map((option, i) => {
           const itemDisabled =
             enumDisabled && enumDisabled.indexOf(option.value) != -1;

--- a/src/widgets/RangeWidget.js
+++ b/src/widgets/RangeWidget.js
@@ -1,7 +1,9 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { Slider } from "@material-ui/lab";
-import { Grid, Typography, InputLabel } from "@material-ui/core";
+import Slider from "@material-ui/lab/Slider";
+import Grid from "@material-ui/core/Grid";
+import Typography from "@material-ui/core/Typography";
+import InputLabel from "@material-ui/core/InputLabel";
 
 import { rangeSpec } from "react-jsonschema-form/lib/utils";
 

--- a/src/widgets/SelectWidget.js
+++ b/src/widgets/SelectWidget.js
@@ -1,14 +1,12 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import PropTypes from "prop-types";
-import {
-  FormHelperText,
-  FormControl,
-  MenuItem,
-  Select,
-  InputLabel,
-  OutlinedInput,
-} from "@material-ui/core";
+import FormHelperText from "@material-ui/core/FormHelperText";
+import FormControl from "@material-ui/core/FormControl";
+import MenuItem from "@material-ui/core/MenuItem";
+import Select from "@material-ui/core/Select";
+import InputLabel from "@material-ui/core/InputLabel";
+import OutlinedInput from "@material-ui/core/OutlinedInput";
 
 const classes = PropTypes.object.isRequired;
 

--- a/src/widgets/TextareaWidget.js
+++ b/src/widgets/TextareaWidget.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { TextField } from "@material-ui/core";
+import TextField from "@material-ui/core/TextField";
 
 function TextareaWidget(props) {
   const {
@@ -10,16 +10,17 @@ function TextareaWidget(props) {
     value,
     required,
     disabled,
-    readonly,
     autofocus,
     onChange,
     onBlur,
     label,
     onFocus,
+    schema,
   } = props;
   const _onChange = ({ target: { value } }) => {
     return onChange(value === "" ? options.emptyValue : value);
   };
+  const readonly = schema ? schema.readOnly : false;
   return (
     <TextField
       id={id}
@@ -27,8 +28,7 @@ function TextareaWidget(props) {
       value={typeof value === "undefined" ? "" : value}
       placeholder={placeholder}
       required={required}
-      disabled={disabled}
-      readOnly={readonly}
+      disabled={disabled || readonly}
       autoFocus={autofocus}
       multiline={true}
       variant="outlined"


### PR DESCRIPTION
I noticed that the application of the inline style for radio group was broken using:
```json
 "numberEnumRadio": {
    "ui:widget": "radio",
    "ui:options": {
      "inline": true
    }
  },
```
Have fixed this by checking the  
```js
const row = options ? options.inline : false;
```

The schema prop was holding the `readOnly` property so was not getting passed through too the component properly.

I have also changed the imports to material-ui to import the single assets being used. In my experience this greatly reduces the file size as importing the named exports like it was imports the only of `@material-ui/core`

```js
// old 
import { Button } from '@material-ui/core'
// changed to
import Button from '@material-ui/core/Button'
```